### PR TITLE
Fixed shield reequip, added torch support

### DIFF
--- a/Scripts/Source/UDCustomDeviceMain.psc
+++ b/Scripts/Source/UDCustomDeviceMain.psc
@@ -1755,14 +1755,10 @@ bool Function CheckRenderDeviceEquipped(Actor akActor, Armor rendDevice)
 	return false ;device is not equipped
 EndFunction
 
-Armor Function GetShield(Actor akActor)
-	if akActor.wornhaskeyword(UDlibs.ArmorShield)
-		Armor loc_shield = akActor.GetWornForm(0x00000200) as Armor
-		if loc_shield.isShield()
-			return loc_shield 
-		else
-			return none
-		endif
+Form Function GetShield(Actor akActor)
+	Form loc_shield = akActor.GetEquippedObject(0)
+	if loc_shield && (loc_shield.GetType() == 26 || loc_shield.GetType() == 31)
+		return loc_shield
 	else
 		return none
 	endif

--- a/Scripts/Source/zadlibs_UDPatch.psc
+++ b/Scripts/Source/zadlibs_UDPatch.psc
@@ -827,8 +827,8 @@ Function EndThirdPersonAnimation(actor akActor, bool[] cameraState, bool permitR
 			return
 		EndIf
 		Form loc_shield = StorageUtil.GetFormValue(akActor,"UD_UnequippedShield",none)
-		StorageUtil.UnsetFormValue(akActor,"UD_UnequippedShield")
 		if loc_shield
+			StorageUtil.UnsetFormValue(akActor,"UD_UnequippedShield")
 			akActor.equipItem(loc_shield,false,true)
 		endif
 		Debug.SendAnimationEvent(akActor, "IdleForceDefaultState")

--- a/Scripts/Source/zadlibs_UDPatch.psc
+++ b/Scripts/Source/zadlibs_UDPatch.psc
@@ -793,7 +793,7 @@ bool[] Function StartThirdPersonAnimation(actor akActor, string animation, bool 
 			EndWhile
 			ret[1] = true
 		EndIf	
-		Armor loc_shield = UDCDmain.GetShield(akActor)
+		Form loc_shield = UDCDmain.GetShield(akActor)
 		if loc_shield
 			akActor.unequipItem(loc_shield,true,true)
 			StorageUtil.SetFormValue(akActor,"UD_UnequippedShield",loc_shield)
@@ -826,7 +826,8 @@ Function EndThirdPersonAnimation(actor akActor, bool[] cameraState, bool permitR
 			UDCDMain.Error("EndThirdPersonAnimation("+GetActorName(akActor)+") - Actor is not loaded (Or is otherwise invalid). Aborting.")
 			return
 		EndIf
-		Armor loc_shield = StorageUtil.GetFormValue(akActor,"UD_UnequippedShield",none) as Armor
+		Form loc_shield = StorageUtil.GetFormValue(akActor,"UD_UnequippedShield",none)
+		StorageUtil.UnsetFormValue(akActor,"UD_UnequippedShield")
 		if loc_shield
 			akActor.equipItem(loc_shield,false,true)
 		endif


### PR DESCRIPTION
Per [report](https://www.loverslab.com/topic/165197-unforgiving-devices/?do=findComment&comment=3800114)
Changed the script so it checks equipped left hand instead of getting worn form, checking for Shield and Light form type, remove keyword check for redundancy, added Storage util value unset so shield is not getting requipped after animation if it was manually removed by player.