### PR TITLE
Inflation plug fix

### DIFF
--- a/Scripts/Source/UD_CustomInflatablePlug_RenderScript.psc
+++ b/Scripts/Source/UD_CustomInflatablePlug_RenderScript.psc
@@ -113,6 +113,34 @@ string Function addInfoString(string str = "")
 	return parent.addInfoString(str)
 EndFunction
 
+bool Function struggleMinigame(int type = -1)
+	if isSentient() || !WearerFreeHands(True) || getPlugInflateLevel() > 0
+		forceOutPlugMinigame()
+	else
+		unlockRestrain()
+		if WearerIsPlayer()
+			debug.notification("You succefully forced out " + deviceInventory.getName())
+		elseif WearerIsFollower()
+			debug.notification(getWearerName() + "s "+ getDeviceName() +" got removed!")
+		endif
+	endif
+	return true
+EndFunction
+
+bool Function struggleMinigameWH(Actor akSource)
+	if isSentient() || !WearerFreeHands(True) || getPlugInflateLevel() > 0
+		forceOutPlugMinigameWH(akSource)
+	else
+		unlockRestrain()
+		if WearerIsPlayer()
+			debug.notification("With help of "+ getHelperName() +", you succefully forced out " + deviceInventory.getName() + " !")
+		elseif WearerIsFollower()
+			debug.notification(getWearerName() + "s "+ getDeviceName() +" got removed!")
+		endif
+	endif
+	return true
+EndFunction
+
 float Function getAccesibility()
 	float loc_res = parent.getAccesibility()
 	if loc_res > 0.0


### PR DESCRIPTION
Override for inflatable plugs to check inflation level on removal. Function is the same as in UD_CustomPlug_RenderScript except || getPlugInflateLevel() > 0 is added in 2 places.

Supposed to disallow player to remove fully or partially inflated plugs immediately.