### PR TITLE
Device lock rework

### DIFF
--- a/Scripts/Source/UD_CustomDevice_EquipScript.psc
+++ b/Scripts/Source/UD_CustomDevice_EquipScript.psc
@@ -193,10 +193,12 @@ Event OnContainerChanged(ObjectReference akNewContainer, ObjectReference akOldCo
 EndEvent
 
 Function openWHMenu(Actor akTarget,Actor akSource)
-    if UDmain.TraceAllowed()    
-        UDCDmain.Log(" NPC menu opened for " + deviceInventory.getName() + " (" + akTarget.getActorBase().getName() + ") by " + akSource.getActorBase().getName(),1)
+    if UDmain.IsEnabled()
+        if UDmain.TraceAllowed()
+            UDCDmain.Log(" NPC menu opened for " + deviceInventory.getName() + " (" + akTarget.getActorBase().getName() + ") by " + akSource.getActorBase().getName(),1)
+        endif
+        UDCDMain.OpenHelpDeviceMenu(getUDScript(akTarget),akSource,UDCDmain.ActorIsFollower(akTarget))
     endif
-    UDCDMain.OpenHelpDeviceMenu(getUDScript(akTarget),akSource,UDCDmain.ActorIsFollower(akTarget))
 EndFunction
 
 UD_CustomDevice_RenderScript Function getUDScript(Actor akActor)
@@ -295,19 +297,16 @@ EndEvent
 
 ;device menu that pops up when Wearer click on this device in inventory
 Function DeviceMenu(Int msgChoice = 0)
-    if UDmain.TraceAllowed()    
-        UDCDmain.Log("DeviceMenu("+MakeDeviceHeader(UDmain.Player,deviceInventory)+")",1)
-    endif
-    
-    if !deviceRendered.haskeyword(UDCDmain.UDlibs.UnforgivingDevice)
-        parent.deviceMenu() ;not patched device
-        return
-    endif
-    UD_CustomDevice_RenderScript device = UDCDmain.getDeviceByInventory(UDmain.Player,deviceInventory)
-    if device
-        UDCDmain.getDeviceByInventory(UDmain.Player,deviceInventory).DeviceMenu(new Bool[30])
-    else
-        UDCDmain.getDeviceScriptByRender(UDmain.Player,deviceRendered).DeviceMenu(new Bool[30])
+    if UDmain.IsEnabled()
+        if UDmain.TraceAllowed()    
+            UDCDmain.Log("DeviceMenu("+MakeDeviceHeader(UDmain.Player,deviceInventory)+")",1)
+        endif
+        UD_CustomDevice_RenderScript device = UDCDmain.getDeviceByInventory(UDmain.Player,deviceInventory)
+        if device
+            UDCDmain.getDeviceByInventory(UDmain.Player,deviceInventory).DeviceMenu(new Bool[30])
+        else
+            UDCDmain.getDeviceScriptByRender(UDmain.Player,deviceRendered).DeviceMenu(new Bool[30])
+        endif
     endif
 EndFunction
 

--- a/Scripts/Source/UD_CustomDevice_NPCSlot.psc
+++ b/Scripts/Source/UD_CustomDevice_NPCSlot.psc
@@ -1745,6 +1745,9 @@ Function InitOrgasmUpdate()
 EndFunction
 
 Function UpdateOrgasm(Float afUpdateTime)
+    if !UDmain.IsEnabled()
+        return
+    endif
     Actor akActor = GetActor()
     CalculateOrgasmProgress()
     ;check orgasm

--- a/Scripts/Source/UD_CustomDevices_NPCSlotsManager.psc
+++ b/Scripts/Source/UD_CustomDevices_NPCSlotsManager.psc
@@ -503,6 +503,26 @@ State UpdatePaused
     Event OnUpdate()
         RegisterForSingleUpdate(UDCDmain.UD_UpdateTime/2)
     EndEvent
+    Event OnUpdateGameTime()
+        RegisterForSingleUpdateGameTime(1.0)
+    endEvent
+    Function UpdateSlot(UD_CustomDevice_NPCSlot akSlot)
+    EndFunction
+    Function UpdateDevices(float fTimePassed)
+    EndFunction
+    Function UpdateSlotDevices(UD_CustomDevice_NPCSlot akSlot, Float afTimePassed)
+    EndFunction
+EndState
+
+State Disabled
+    Function UpdateSlots()
+    EndFunction
+    Event OnUpdate()
+        RegisterForSingleUpdate(UDCDmain.UD_UpdateTime/2)
+    EndEvent
+    Event OnUpdateGameTime()
+        RegisterForSingleUpdateGameTime(1.0)
+    endEvent
     Function UpdateSlot(UD_CustomDevice_NPCSlot akSlot)
     EndFunction
     Function UpdateDevices(float fTimePassed)

--- a/Scripts/Source/UD_NPCInteligence.psc
+++ b/Scripts/Source/UD_NPCInteligence.psc
@@ -198,3 +198,11 @@ State Paused
     Function Evaluate()
     EndFunction
 EndState
+
+State Disabled
+    Event OnUpdate()
+        RegisterForSingleUpdate(3*UD_UpdateTime)
+    EndEvent
+    Function Evaluate()
+    EndFunction
+EndState

--- a/Scripts/Source/UD_OrgasmUpdater.psc
+++ b/Scripts/Source/UD_OrgasmUpdater.psc
@@ -99,3 +99,13 @@ State Paused
     Function Evaluate()
     EndFunction
 EndState
+State Disabled
+    Event OnUpdate()
+        RegisterForSingleUpdate(UD_UpdateTime*3)
+    EndEvent
+    Bool Function SlotOrgasmUpdateEnabled(UD_CustomDevice_NPCSlot akSlot)
+        return False
+    EndFunction
+    Function Evaluate()
+    EndFunction
+EndState

--- a/Scripts/Source/UD_Patcher.psc
+++ b/Scripts/Source/UD_Patcher.psc
@@ -127,7 +127,7 @@ Function patchHeavyBondage(UD_CustomHeavyBondage_RenderScript device)
     if (StringUtil.find(device.deviceInventory.getName(),"High Security") != -1 || StringUtil.find(device.deviceInventory.getName(),"Secure") != -1)
         device.UD_durability_damage_base = fRange(device.UD_durability_damage_base/4.0,0.05,100.0)
         device.UD_StruggleCritDuration = 0.5
-        device.UD_Locks = UD_MinLocks
+        ;device.UD_Locks = UD_MinLocks
         device.UD_LockpickDifficulty = 100
         if device.UD_LockAccessDifficulty < 85
             device.UD_LockAccessDifficulty = 85
@@ -154,7 +154,7 @@ Function patchBlindfold(UD_CustomBlindfold_RenderScript device)
     CheckLocks(device,false,30)
     ;materials
     if StringUtil.find(device.deviceInventory.getName(),"Extreme") != -1 || (StringUtil.find(device.deviceInventory.getName(),"High Security") != -1 || StringUtil.find(device.deviceInventory.getName(),"Secure") != -1)
-        device.UD_Locks = UD_MinLocks
+        ;device.UD_Locks = UD_MinLocks
         device.UD_ResistPhysical = Utility.randomFloat(0.4,0.8)
         device.UD_ResistMagicka = Utility.randomFloat(0.2,1.0)
     endif
@@ -169,7 +169,7 @@ Function patchGag(UD_CustomGag_RenderScript device)
     patchDefaultValues(device,loc_currentmult)
     
     if StringUtil.find(device.deviceInventory.getName(),"Extreme") != -1 || (StringUtil.find(device.deviceInventory.getName(),"High Security") != -1 || StringUtil.find(device.deviceInventory.getName(),"Secure") != -1)
-        device.UD_Locks = UD_MinLocks
+        ;device.UD_Locks = UD_MinLocks
     endif
     
     checkLooseModifier(device,30,0.05, 0.15)
@@ -199,7 +199,7 @@ Function patchBelt(UD_CustomBelt_RenderScript device)
     elseif (StringUtil.find(device.deviceInventory.getName(),"Rope") != -1)
         device.UD_ResistPhysical = Utility.randomFloat(-0.5,0.0)
         device.UD_ResistMagicka = Utility.randomFloat(-0.1,0.1)
-        device.UD_Locks = 0
+        ;device.UD_Locks = 0
     endif
     
     if device as UD_CustomCrotchDevice_RenderScript
@@ -214,7 +214,7 @@ Function patchPlug(UD_CustomPlug_RenderScript device)
     Float loc_currentmult = UD_PatchMult_Plug*UD_PatchMult*GetPatchDifficulty(device)
     patchDefaultValues(device,loc_currentmult)
     
-    device.UD_Locks = 0
+    ;device.UD_Locks = 0
     device.UD_durability_damage_base = Utility.randomFloat(10.0,20.0)/loc_currentmult
     device.UD_VibDuration = Math.Floor(Utility.randomInt(45,80)*fRange(loc_currentmult,0.5,5.0))
     device.UD_OrgasmMult  = Utility.randomFloat(0.75,1.5)*fRange(loc_currentmult,0.7,1.0)
@@ -455,7 +455,7 @@ Function checkInventoryScript(UD_CustomDevice_RenderScript device,int argControl
         endif
         
         if !inventoryScript.deviceKey && inventoryScript.LockPickEscapeChance == 0.0
-            device.UD_Locks = 0
+            ;device.UD_Locks = 0
         elseif !device.UD_durability_damage_base && device.UD_Locks == 0 ;inventoryScript.deviceKey; && inventoryScript.LockAccessDifficulty < 100.0
             CheckLocks(device)
         endif
@@ -479,13 +479,13 @@ Function CheckLocks(UD_CustomDevice_RenderScript device,bool bEven = false,int i
     endif
     
     if UD_MaxLocks == UD_MinLocks
-        device.UD_Locks = UD_MaxLocks
+        ;device.UD_Locks = UD_MaxLocks
         return
     endif
     
     ;device have no locks
     if Utility.randomInt(0,99) < iChanceNone
-        device.UD_Locks = 0
+        ;device.UD_Locks = 0
         return
     endif
     
@@ -493,24 +493,24 @@ Function CheckLocks(UD_CustomDevice_RenderScript device,bool bEven = false,int i
         int loc_res = Utility.randomInt(UD_MinLocks,UD_MaxLocks)
         
         if !loc_res
-            device.UD_Locks = 1 ;can't have device without lock!
+            ;device.UD_Locks = 1 ;can't have device without lock!
             return
         endif
         
         if (loc_res % 2) 
             ;is not even
             if loc_res + 1 <= UD_MaxLocks
-                device.UD_Locks = loc_res + 1
+                ;device.UD_Locks = loc_res + 1
             elseif loc_res - 1 >= UD_MinLocks
-                device.UD_Locks = loc_res - 1
+                ;device.UD_Locks = loc_res - 1
             else
-                device.UD_Locks = loc_res ;fuck it
+                ;device.UD_Locks = loc_res ;fuck it
             endif
         else
-            device.UD_Locks = loc_res
+            ;device.UD_Locks = loc_res
         endif
     else
-        device.UD_Locks = Utility.randomInt(UD_MinLocks,UD_MaxLocks)
+        ;device.UD_Locks = Utility.randomInt(UD_MinLocks,UD_MaxLocks)
     endif
 EndFunction
 
@@ -552,6 +552,10 @@ Function patchDefaultValues(UD_CustomDevice_RenderScript device,Float fMult)
     
     checkSentientModifier(device,Round(15*fMult),1.0)
     checkHealModifier(device,10)
+    
+    device.CreateLock(aiDifficulty = 10, aiAccess = 100, asName = "Test Lock",abAdd = True, aiShields = 3)
+    device.CreateLock(aiDifficulty = 90, aiAccess = 10, asName = "Test Lock 2",abAdd = True, aiShields = 1)
+    device.CreateLock(aiDifficulty = 10, aiAccess = 100, asName = "",abAdd = True, aiShields = 3)
 EndFunction
 
 ;check resist, so it can never bee too big or too low

--- a/Scripts/Source/UD_UserInputScript.psc
+++ b/Scripts/Source/UD_UserInputScript.psc
@@ -157,31 +157,35 @@ State Minigame
 EndState
 
 Event OnKeyDown(Int KeyCode)
-    bool loc_menuopen = UDmain.IsMenuOpen()
-    if !loc_menuopen ;only if player is not in menu
-        if UD_EasyGamepadMode && Game.UsingGamepad()
-            if KeyCode == UD_GamepadKey
-                ;show menu
-                ShowGamePadMenu()
-            endif
-        else
-            if KeyCode == UDCDMain.PlayerMenu_KeyCode
-                UDCDMain.PlayerMenu()
+    if UDmain.IsEnabled()
+        bool loc_menuopen = UDmain.IsMenuOpen()
+        if !loc_menuopen ;only if player is not in menu
+            if UD_EasyGamepadMode && Game.UsingGamepad()
+                if KeyCode == UD_GamepadKey
+                    ;show menu
+                    ShowGamePadMenu()
+                endif
+            else
+                if KeyCode == UDCDMain.PlayerMenu_KeyCode
+                    UDCDMain.PlayerMenu()
+                endif
             endif
         endif
     endif
 EndEvent
 
 Event OnKeyUp(Int KeyCode, Float HoldTime)
-    if !UDmain.IsMenuOpen() && !(UD_EasyGamepadMode && Game.UsingGamepad())
-        if KeyCode == UDCDMain.StruggleKey_Keycode
-            if HoldTime < 0.2
-                OpenLastDeviceMenu()
-            else
-                OpenDeviceMenu()
+    if UDmain.IsEnabled()
+        if !UDmain.IsMenuOpen() && !(UD_EasyGamepadMode && Game.UsingGamepad())
+            if KeyCode == UDCDMain.StruggleKey_Keycode
+                if HoldTime < 0.2
+                    OpenLastDeviceMenu()
+                else
+                    OpenDeviceMenu()
+                endif
+            elseif KeyCode == UDCDmain.NPCMenu_Keycode
+                OpenNPCMenu(HoldTime > 0.2)
             endif
-        elseif KeyCode == UDCDmain.NPCMenu_Keycode
-            OpenNPCMenu(HoldTime > 0.2)
         endif
     endif
 EndEvent

--- a/Scripts/Source/UnforgivingDevicesMain.psc
+++ b/Scripts/Source/UnforgivingDevicesMain.psc
@@ -712,6 +712,28 @@ int Function iRange(int iValue,int iMin,int iMax) global
     return iValue
 EndFunction
 
+;returns true if the passed INT value is in range from iMin to iMax
+Bool Function iInRange(int aiValue,int aiMin,int aiMax) global
+    if aiValue > aiMax
+        return false
+    endif
+    if aiValue < aiMin
+        return false
+    endif
+    return true
+EndFunction
+
+;returns true if the passed FLOAT value is in range from iMin to iMax
+Bool Function fInRange(float afValue,float afMin,float afMax) global
+    if afValue > afMax
+        return false
+    endif
+    if afValue < afMin
+        return false
+    endif
+    return true
+EndFunction
+
 string Function formatString(string str,int floatPoints) global
     int float_point =  StringUtil.find(str,".")
     if (float_point == -1)

--- a/Scripts/Source/UnforgivingDevicesMain.psc
+++ b/Scripts/Source/UnforgivingDevicesMain.psc
@@ -210,13 +210,47 @@ Event OnInit()
     RegisterForSingleUpdate(0.1)
 EndEvent
 
+Bool Property _Disabled = False Auto Hidden Conditional
+Bool Property _Updating = False Auto Hidden Conditional
+
+;returns true if mod is currently updating. Mods should be threated as disabled when this happends
+Bool Function IsUpdating()
+    return _Updating
+EndFunction
+
+;returns true if UD is enabled
+Bool Function IsEnabled()
+    return !_Disabled && !_Updating
+EndFunction
+
+;Disables, Enables UD
+Function DISABLE()
+    _Disabled = True
+    UDNPCM.GoToState("Disabled") ;disable NPC manager, disabling all device updates
+    UDAI.GoToState("Disabled") ;disable AI updates
+    UDOM.GoToState("Disabled") ;disable orgasm updates
+EndFunction
+Function ENABLE()
+    _Disabled = False
+    UDNPCM.GoToState("")
+    UDAI.GoToState("")
+    UDOM.GoToState("")
+EndFunction
+
 Function OnGameReload()
+    if _Disabled
+        return ;mod is disabled, do nothing
+    endif
+    
+    _Updating = True
+    DISABLE()
+    
     if !Ready
         Utility.waitMenuMode(2.5)
     endif
     
     Utility.waitMenuMode(3.5)
-        
+    
     CLog("OnGameReload() called! - Updating Unforgiving Devices...")
     
     ;update all scripts
@@ -261,6 +295,9 @@ Function OnGameReload()
     UDAbadonQuest.Update()
     
     CLog("Unforgiving Devices updated.")
+    
+    _Updating = False
+    ENABLE()
 EndFunction
 
 Event OnUpdate()

--- a/Scripts/Source/zadlibs_UDPatch.psc
+++ b/Scripts/Source/zadlibs_UDPatch.psc
@@ -1241,7 +1241,8 @@ Bool Function JamLock(actor akActor, keyword zad_DeviousDevice)
     if loc_renderdevice
         if loc_renderdevice.HasKeyword(UDlibs.UnforgivingDevice)
             UD_CustomDevice_RenderScript loc_device = UDCDmain.getDeviceByRender(akActor, loc_renderdevice)
-            loc_device.UD_JammedLocks = loc_device.UD_CurrentLocks
+            loc_device.JammAllLocks(True)
+            ;loc_device.UD_JammedLocks = loc_device.UD_CurrentLocks
         endif
         StorageUtil.SetIntValue(akActor, "zad_Equipped" + LookupDeviceType(zad_DeviousDevice) + "_LockJammedStatus", 1)
         return True
@@ -1260,7 +1261,8 @@ Bool Function UnJamLock(actor akActor, keyword zad_DeviousDevice)
     if loc_renderdevice
         if loc_renderdevice.HasKeyword(UDlibs.UnforgivingDevice)
             UD_CustomDevice_RenderScript loc_device = UDCDmain.getDeviceByRender(akActor, loc_renderdevice)
-            loc_device.UD_JammedLocks = 0
+            loc_device.JammAllLocks(False)
+            ;loc_device.UD_JammedLocks = 0
         endif
         StorageUtil.SetIntValue(akActor, "zad_Equipped" + LookupDeviceType(zad_DeviousDevice) + "_LockJammedStatus", 0)
         return True


### PR DESCRIPTION
Total rework of device locks. All devices will now have set number of locks (depending on device type). 

- The number will not change. Every lock can have different difficulty and accessibility. 
- All locks can also have lockpick shields. Lock can't be unlocked with lockpicking until all shields are removed. Basically, if device have 5 shields, it means that lock needs to be lockpicked 6 times for it to be removed.

Whole idea is that for example, the catsuit can have 5 locks, 1 on back, 2 on arms and 2 on legs. And every lock can have different accessibility (back being hardest to reach). Unlocking locks now also provide stronger boost to struggle minigames (up to 300%, might add MCM setting for it)